### PR TITLE
Add favicon to TRACE badge generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>TRACE Badge Generator</title>
+<link rel="icon" type="image/png" href="https://storage.googleapis.com/art_homelessness/android-chrome-192x192.png" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <style>
   :root {


### PR DESCRIPTION
## Summary
- add external PNG favicon to the HTML head

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68afd0b4b5f08332b2757caaa15dd87f