### PR TITLE
feat: add smart model selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,57 +242,120 @@
     color: #475569;
   }
 
-  .model-selector {
+  .model-selector-v2 {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    max-width: 100%;
-    overflow: hidden;
+    gap: 0.5rem;
   }
 
-  .model-dropdowns {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+  .model-tabs {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .model-tabs .tab {
+    padding: 0.25rem 0.5rem;
+    border: none;
+    background: #e2e8f0;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .model-tabs .tab.active {
+    background: #3b82f6;
+    color: white;
+  }
+
+  .tab-panel {
+    display: block;
+  }
+
+  .model-categories {
+    display: flex;
+    flex-direction: column;
     gap: 0.75rem;
-    max-width: 100%;
   }
 
-  .dropdown-group {
+  .model-category h4 {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #374151;
+  }
+
+  .frequent-section {
+    margin-top: 0.5rem;
+  }
+
+  .search-results {
+    margin-top: 0.5rem;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .search-result {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    cursor: pointer;
+  }
+
+  .search-result:hover {
+    background: #f1f5f9;
+  }
+
+  .search-result .model-id {
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+
+  .model-pills {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+  }
+
+  .model-pill {
+    padding: 0.5rem 0.75rem;
+    border: 2px solid #e2e8f0;
+    border-radius: 20px;
+    background: white;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
     gap: 0.25rem;
   }
 
-  .dropdown-group label {
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: #374151;
-    margin: 0;
+  .model-pill:hover {
+    border-color: #3b82f6;
+    background: #eff6ff;
   }
 
-  .make-select,
-  .model-select {
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
-    font-size: 0.9rem;
-    background: white;
-    width: 100%;
-    max-width: 100%;
+  .model-pill.selected {
+    background: #3b82f6;
+    color: white;
+    border-color: #3b82f6;
   }
 
-  .model-select:disabled {
-    background: #f9fafb;
-    color: #9ca3af;
-    cursor: not-allowed;
+  .model-pill.suggested {
+    border-color: #10b981;
   }
 
-  .model-select option,
-  .make-select option {
-    white-space: normal;
-    word-wrap: break-word;
-    padding: 0.25rem 0.5rem;
-    line-height: 1.4;
+  .model-pill .provider {
+    opacity: 0.7;
+    font-size: 0.75rem;
+  }
+
+  .model-pill .remove {
+    margin-left: 0.5rem;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .model-pill.selected:hover .remove {
+    opacity: 1;
   }
 
   .selected-models {
@@ -781,10 +844,6 @@
       grid-template-columns: 1fr;
     }
     
-    .model-dropdowns {
-      grid-template-columns: 1fr;
-    }
-    
     .controls-section {
       min-width: unset;
       max-width: unset;
@@ -835,29 +894,29 @@
           </button>
         </div>
         
-        <div class="model-selector">
-          <div class="model-dropdowns">
-            <div class="dropdown-group">
-              <label for="make-select">Make:</label>
-              <select class="make-select" id="make-select">
-                <option value="">Select provider...</option>
-              </select>
-            </div>
-            <div class="dropdown-group">
-              <label for="model-select">Model:</label>
-              <select class="model-select" id="model-select" disabled>
-                <option value="">Select model...</option>
-              </select>
+        <div class="model-selector-v2">
+          <div class="model-tabs">
+            <button class="tab active" data-tab="recent">Recent</button>
+            <button class="tab" data-tab="popular">Popular</button>
+            <button class="tab" data-tab="search">Search</button>
+          </div>
+
+          <div class="tab-panel" id="recent-panel">
+            <div class="model-pills"></div>
+            <div class="frequent-section">
+              <small>Most Used:</small>
+              <div class="frequent-models"></div>
             </div>
           </div>
-          
-          <button class="button" id="add-model-btn" onclick="addSelectedModel()" disabled>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="12" y1="5" x2="12" y2="19"></line>
-              <line x1="5" y1="12" x2="19" y2="12"></line>
-            </svg>
-            Add Model
-          </button>
+
+          <div class="tab-panel" id="popular-panel" style="display:none">
+            <div class="model-categories"></div>
+          </div>
+
+          <div class="tab-panel" id="search-panel" style="display:none">
+            <input type="text" class="model-search" placeholder="Type to search models..." autocomplete="off">
+            <div class="search-results"></div>
+          </div>
         </div>
 
         <div class="selected-models" id="selected-models-container" style="display: none;">
@@ -1032,6 +1091,247 @@
     let aiModels = [];
     let selectedModels = [];
     let currentWizardSection = '';
+    let modelSearch;
+
+    const POPULAR_MODELS = {
+      'Featured': [
+        {id: 'openai/gpt-4o', name: 'GPT-4o', icon: '🟢'},
+        {id: 'anthropic/claude-3.5-sonnet', name: 'Claude 3.5', icon: '🔷'},
+        {id: 'google/gemini-pro-1.5', name: 'Gemini Pro', icon: '🔶'},
+        {id: 'openai/o1-preview', name: 'o1', icon: '⚡'}
+      ],
+      'Image': [
+        {id: 'openai/dall-e-3', name: 'DALL-E 3', icon: '🎨'},
+        {id: 'midjourney/v6', name: 'Midjourney', icon: '🖼️'},
+        {id: 'stability/sdxl', name: 'Stable Diffusion', icon: '🎭'}
+      ],
+      'Open Source': [
+        {id: 'meta/llama-3.1-405b', name: 'Llama 3.1', icon: '🦙'},
+        {id: 'mistral/mixtral-8x7b', name: 'Mixtral', icon: '🌟'}
+      ]
+    };
+
+    class ModelMemory {
+      constructor() {
+        this.storage = window.localStorage;
+        this.STORAGE_KEY = 'trace_models';
+        this.MAX_RECENT = 8;
+      }
+      getModelHistory() {
+        const data = JSON.parse(this.storage.getItem(this.STORAGE_KEY) || '{}');
+        return {
+          recent: data.recent || [],
+          frequency: data.frequency || {},
+          favorites: data.favorites || []
+        };
+      }
+      addModel(model) {
+        const data = this.getModelHistory();
+        data.frequency[model.id] = (data.frequency[model.id] || 0) + 1;
+        data.recent = data.recent.filter(m => m.id !== model.id);
+        data.recent.unshift(model);
+        data.recent = data.recent.slice(0, this.MAX_RECENT);
+        this.storage.setItem(this.STORAGE_KEY, JSON.stringify(data));
+      }
+      getMostUsed(limit = 4) {
+        const data = this.getModelHistory();
+        return Object.entries(data.frequency)
+          .sort(([,a],[,b]) => b - a)
+          .slice(0, limit)
+          .map(([id]) => data.recent.find(m => m.id === id))
+          .filter(Boolean);
+      }
+    }
+    const modelMemory = new ModelMemory();
+
+    class ModelPresets {
+      savePreset(name, models) {
+        const presets = JSON.parse(localStorage.getItem('trace_presets') || '{}');
+        presets[name] = { models: models, created: Date.now(), useCount: 0 };
+        localStorage.setItem('trace_presets', JSON.stringify(presets));
+      }
+      loadPreset(name) {
+        const presets = JSON.parse(localStorage.getItem('trace_presets') || '{}');
+        if (presets[name]) {
+          presets[name].useCount++;
+          localStorage.setItem('trace_presets', JSON.stringify(presets));
+          return presets[name].models;
+        }
+        return [];
+      }
+    }
+
+    class ModelSearch {
+      constructor(models) {
+        this.models = models;
+        this.searchInput = document.querySelector('.model-search');
+        this.resultsDiv = document.querySelector('.search-results');
+        this.initSearch();
+        if (this.resultsDiv) {
+          this.resultsDiv.addEventListener('click', (e) => {
+            const res = e.target.closest('.search-result');
+            if (!res) return;
+            const id = res.dataset.id;
+            const model = this.models.find(m => m.id === id);
+            if (model) {
+              handleModelSelect(model);
+              this.clearResults();
+              if (this.searchInput) this.searchInput.value = '';
+            }
+          });
+        }
+      }
+      setModels(models) { this.models = models; }
+      initSearch() {
+        let debounceTimer;
+        if (!this.searchInput) return;
+        this.searchInput.addEventListener('input', (e) => {
+          clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => {
+            this.search(e.target.value);
+          }, 200);
+        });
+      }
+      search(query) {
+        if (query.length < 2) {
+          this.clearResults();
+          return;
+        }
+        const results = this.models.filter(m =>
+          m.name.toLowerCase().includes(query.toLowerCase()) ||
+          m.id.toLowerCase().includes(query.toLowerCase())
+        ).slice(0, 10);
+        this.resultsDiv.innerHTML = results.map(model => `
+          <div class="search-result" data-id="${model.id}">
+            <div class="model-name">${this.highlightMatch(model.name, query)}</div>
+            <div class="model-id">${this.highlightMatch(model.id, query)}</div>
+          </div>
+        `).join('');
+      }
+      highlightMatch(text, query) {
+        const regex = new RegExp(`(${query})`, 'gi');
+        return text.replace(regex, '<mark>$1</mark>');
+      }
+      clearResults() {
+        if (this.resultsDiv) this.resultsDiv.innerHTML = '';
+      }
+    }
+
+    function getModelById(id) {
+      return aiModels.find(m => m.id === id) ||
+        Object.values(POPULAR_MODELS).flat().find(m => m.id === id) ||
+        modelMemory.getModelHistory().recent.find(m => m.id === id);
+    }
+
+    function handleModelSelect(model) {
+      if (!model || selectedModels.find(m => m.id === model.id)) return;
+      selectedModels.push(model);
+      modelMemory.addModel(model);
+      updateSelectedModelsDisplay();
+      updateCitation();
+      renderRecentModels();
+    }
+
+    function renderRecentModels() {
+      const history = modelMemory.getModelHistory();
+      const pills = document.querySelector('#recent-panel .model-pills');
+      const freq = document.querySelector('.frequent-models');
+      if (pills) {
+        pills.innerHTML = history.recent.map(m =>
+          `<div class="model-pill recent-model" data-id="${m.id}">${m.icon || ''}<span>${m.name}</span></div>`
+        ).join('');
+      }
+      if (freq) {
+        const most = modelMemory.getMostUsed(3);
+        freq.innerHTML = most.map(m =>
+          `<div class="model-pill" data-id="${m.id}">${m.icon || ''}<span>${m.name}</span></div>`
+        ).join('');
+      }
+    }
+
+    function renderPopularModels() {
+      const container = document.querySelector('.model-categories');
+      if (!container) return;
+      container.innerHTML = '';
+      Object.entries(POPULAR_MODELS).forEach(([category, models]) => {
+        const section = document.createElement('div');
+        section.className = 'model-category';
+        const heading = document.createElement('h4');
+        heading.textContent = category;
+        section.appendChild(heading);
+        const pills = document.createElement('div');
+        pills.className = 'model-pills';
+        models.forEach(m => {
+          const pill = document.createElement('div');
+          pill.className = 'model-pill';
+          pill.dataset.id = m.id;
+          pill.innerHTML = `${m.icon}<span>${m.name}</span>`;
+          pills.appendChild(pill);
+        });
+        section.appendChild(pills);
+        container.appendChild(section);
+      });
+    }
+
+    function setupTabs() {
+      document.querySelectorAll('.model-tabs .tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+          document.querySelectorAll('.model-tabs .tab').forEach(t => t.classList.remove('active'));
+          tab.classList.add('active');
+          document.querySelectorAll('.tab-panel').forEach(panel => panel.style.display = 'none');
+          const panel = document.getElementById(`${tab.dataset.tab}-panel`);
+          if (panel) panel.style.display = 'block';
+        });
+      });
+    }
+
+    function highlightSuggestedModels(ids) {
+      document.querySelectorAll('.model-pill').forEach(pill => {
+        pill.classList.toggle('suggested', ids.includes(pill.dataset.id));
+      });
+    }
+
+    function suggestModelsForRole(role) {
+      const suggestions = {
+        'A': ['openai/gpt-4o', 'anthropic/claude-3.5-sonnet'],
+        'D': ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o'],
+        'S': ['openai/o1-preview', 'google/gemini-pro-1.5'],
+        'N': ['openai/o1-preview', 'anthropic/claude-3.5-sonnet'],
+        'E': ['openai/gpt-4o', 'meta/llama-3.1-405b'],
+        'C': ['openai/dall-e-3', 'midjourney/v6', 'anthropic/claude-3.5-sonnet']
+      };
+      return suggestions[role] || [];
+    }
+
+    document.addEventListener('change', (e) => {
+      if (e.target.name === 'role') {
+        const suggested = suggestModelsForRole(e.target.value);
+        highlightSuggestedModels(suggested);
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        const input = document.querySelector('.model-search');
+        if (input) input.focus();
+      }
+      if (e.target.tagName !== 'INPUT' && e.key >= '1' && e.key <= '9') {
+        const index = parseInt(e.key) - 1;
+        const recentModels = document.querySelectorAll('.recent-model');
+        if (recentModels[index]) recentModels[index].click();
+      }
+    });
+
+    const selector = document.querySelector('.model-selector-v2');
+    if (selector) {
+      selector.addEventListener('click', (e) => {
+        const pill = e.target.closest('.model-pill');
+        if (!pill) return;
+        const model = getModelById(pill.dataset.id);
+        handleModelSelect(model);
+      });
+    }
 
     const WIZARD_DATA = {
       role: {
@@ -1167,63 +1467,6 @@
       }
     });
 
-    // Make selection handling
-    document.getElementById('make-select').addEventListener('change', (e) => {
-      const modelSelect = document.getElementById('model-select');
-      const addBtn = document.getElementById('add-model-btn');
-      
-      modelSelect.innerHTML = '<option value="">Select model...</option>';
-      modelSelect.disabled = !e.target.value;
-      addBtn.disabled = true;
-      
-      if (e.target.value) {
-        const provider = e.target.value;
-        const providerModels = aiModels.filter(model => model.id.startsWith(provider + '/'));
-        
-        providerModels
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .forEach(model => {
-            const option = document.createElement('option');
-            option.value = model.id;
-            option.textContent = model.name; // Full name, no truncation
-            modelSelect.appendChild(option);
-          });
-      }
-    });
-
-    // Model selection handling
-    document.getElementById('model-select').addEventListener('change', (e) => {
-      const addBtn = document.getElementById('add-model-btn');
-      addBtn.disabled = !e.target.value;
-    });
-
-    // Add selected model
-    function addSelectedModel() {
-      const makeSelect = document.getElementById('make-select');
-      const modelSelect = document.getElementById('model-select');
-      
-      if (!makeSelect.value || !modelSelect.value) return;
-      
-      const selectedModel = aiModels.find(model => model.id === modelSelect.value);
-      if (!selectedModel) return;
-      
-      // Check if already selected
-      if (selectedModels.find(m => m.id === selectedModel.id)) {
-        alert('This model is already selected.');
-        return;
-      }
-      
-      selectedModels.push(selectedModel);
-      updateSelectedModelsDisplay();
-      updateCitation();
-      
-      // Reset selections
-      makeSelect.value = '';
-      modelSelect.innerHTML = '<option value="">Select model...</option>';
-      modelSelect.disabled = true;
-      document.getElementById('add-model-btn').disabled = true;
-    }
-
     // Remove selected model
     function removeSelectedModel(modelId) {
       selectedModels = selectedModels.filter(m => m.id !== modelId);
@@ -1232,7 +1475,6 @@
     }
 
     // Make these functions global
-    window.addSelectedModel = addSelectedModel;
     window.removeSelectedModel = removeSelectedModel;
     window.downloadBadge = downloadBadge;
     window.copyCitation = copyCitation;
@@ -1392,71 +1634,29 @@
 
     // Load AI models from OpenRouter API
     async function loadAIModels() {
-      const makeSelect = document.getElementById('make-select');
-      const modelSelect = document.getElementById('model-select');
       const status = document.getElementById('model-status');
       const refreshBtn = document.querySelector('.refresh-btn');
-      
       try {
         refreshBtn.disabled = true;
         status.innerHTML = '<div class="status-message">Loading latest AI models...</div>';
-        
         const response = await fetch('https://openrouter.ai/api/v1/models');
-        
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
-        
         const data = await response.json();
         aiModels = data.data || [];
-        
-        // Clear existing options
-        makeSelect.innerHTML = '<option value="">Select provider...</option>';
-        modelSelect.innerHTML = '<option value="">Select model...</option>';
-        modelSelect.disabled = true;
-        
-        // Get unique providers
-        const providers = [...new Set(aiModels.map(model => model.id.split('/')[0]))];
-        
-        // Sort providers, prioritize major ones
-        const priorityProviders = ['openai', 'anthropic', 'google', 'meta-llama', 'microsoft'];
-        const sortedProviders = providers.sort((a, b) => {
-          const aIndex = priorityProviders.indexOf(a);
-          const bIndex = priorityProviders.indexOf(b);
-          if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-          if (aIndex !== -1) return -1;
-          if (bIndex !== -1) return 1;
-          return a.localeCompare(b);
-        });
-        
-        // Populate make dropdown
-        sortedProviders.forEach(provider => {
-          const option = document.createElement('option');
-          option.value = provider;
-          option.textContent = provider.charAt(0).toUpperCase() + provider.slice(1);
-          makeSelect.appendChild(option);
-        });
-        
-        status.innerHTML = `<div class="status-message status-success">✓ Loaded ${aiModels.length} AI models from ${providers.length} providers</div>`;
-        
-        setTimeout(() => {
-          status.innerHTML = '';
-        }, 3000);
-        
+        status.innerHTML = `<div class="status-message status-success">✓ Loaded ${aiModels.length} AI models</div>`;
+        if (modelSearch) {
+          modelSearch.setModels(aiModels);
+        } else {
+          modelSearch = new ModelSearch(aiModels);
+        }
       } catch (error) {
         console.error('Failed to load AI models:', error);
         status.innerHTML = `<div class="status-message status-error">⚠ Failed to load models: ${error.message}</div>`;
-        
-        // Add fallback providers
-        makeSelect.innerHTML = `
-          <option value="">Select provider...</option>
-          <option value="openai">OpenAI</option>
-          <option value="anthropic">Anthropic</option>
-          <option value="google">Google</option>
-          <option value="meta-llama">Meta</option>
-        `;
       } finally {
         refreshBtn.disabled = false;
+        setTimeout(() => { status.innerHTML = ''; }, 3000);
       }
     }
 
@@ -1712,6 +1912,9 @@ ${selectedModels.length ? 'Models: ' + selectedModels.map(m => m.name).join(', '
 
     // Initialize
     paint();
+    renderPopularModels();
+    renderRecentModels();
+    setupTabs();
     loadAIModels();
     updateBadgeModelsDisplay();
   </script>


### PR DESCRIPTION
## Summary
- replace dropdown-based model selection with quick-access grid and search
- persist recent and frequent models in localStorage
- initialize selector with popular, recent, and searchable models

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68afd5c7be548332a851ecdb6cb18a24