### PR TITLE
Display model name beneath badge and include in export

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,6 +335,20 @@
       gap: 1.5rem;
     }
 
+    .badge-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .model-name {
+      margin-top: 12px;
+      font-size: 0.85em;
+      color: #666;
+      font-style: italic;
+      text-align: center;
+    }
+
     .badge {
       width: var(--badge);
       height: var(--badge);
@@ -605,11 +619,14 @@
     <!-- Center Panel: Badge -->
     <div class="panel">
       <div class="badge-container">
-        <div id="badge" class="badge">
-          <div class="cell"><span class="code"></span><span class="label"></span></div>
-          <div class="cell"><span class="code"></span><span class="label"></span></div>
-          <div class="cell"><span class="code"></span><span class="label"></span></div>
-          <div class="cell"><span class="code"></span><span class="label"></span></div>
+        <div id="badge-wrapper" class="badge-wrapper">
+          <div id="badge" class="badge">
+            <div class="cell"><span class="code"></span><span class="label"></span></div>
+            <div class="cell"><span class="code"></span><span class="label"></span></div>
+            <div class="cell"><span class="code"></span><span class="label"></span></div>
+            <div class="cell"><span class="code"></span><span class="label"></span></div>
+          </div>
+          <div id="model-name" class="model-name"></div>
         </div>
 
         <div class="style-options">
@@ -883,7 +900,8 @@
       const traceCode = `${role.map(r => r.value).join('') || '_'}-${data.map(d => d.value).join('') || '_'}-${method.map(m => m.value).join('') || '_'}-${review.map(r => r.value).join('') || '_'}`;
       
       // Build natural language description
-      let naturalText = "I used AI to ";
+      const modelNames = selectedModels.map(m => m.name);
+      let naturalText = `I used AI${modelNames.length ? ` (${modelNames.join(' + ')})` : ''} to `;
       
       if (role.length > 0) {
         const parts = role.map(r => {
@@ -960,32 +978,13 @@
       }
       
       naturalText += ".";
-      
-      if (selectedModels.length > 0) {
-        if (selectedModels.length === 1) {
-          naturalText += ` The AI model used was ${selectedModels[0].name}.`;
-        } else if (selectedModels.length === 2) {
-          naturalText += ` The AI models used were ${selectedModels[0].name} and ${selectedModels[1].name}.`;
-        } else {
-          const lastModel = selectedModels[selectedModels.length - 1];
-          const otherModels = selectedModels.slice(0, -1);
-          naturalText += ` The AI models used were ${otherModels.map(m => m.name).join(', ')}, and ${lastModel.name}.`;
-        }
-      }
-      
+
       // Formal citation
-      let formal = `AI Disclosure (${new Date().toISOString().split('T')[0]})\nTRACE: ${traceCode}\n\n`;
+      let formal = `AI Disclosure (${new Date().toISOString().split('T')[0]})\nTRACE: ${traceCode}${modelNames.length ? ' via ' + modelNames.join(' + ') : ''}\n\n`;
       formal += `Role: ${role.length ? role.map(r => TAGS.role.find(t => t.code === r.value).label).join(', ') : 'Unspecified'}\n`;
       formal += `Data: ${data.length ? data.map(d => TAGS.data.find(t => t.code === d.value).label).join(', ') : 'Unspecified'}\n`;
       formal += `Method: ${method.length ? method.map(m => TAGS.method.find(t => t.code === m.value).label).join(', ') : 'Unspecified'}\n`;
       formal += `Review: ${review.length ? review.map(r => TAGS.review.find(t => t.code === r.value).label).join(', ') : 'None'}`;
-      
-      if (selectedModels.length > 0) {
-        formal += `\n\nAI Models Used:\n`;
-        selectedModels.forEach(m => {
-          formal += `• ${m.name} (${m.id})\n`;
-        });
-      }
       
       document.getElementById('tab-formal').textContent = formal;
       document.getElementById('tab-natural').textContent = naturalText;
@@ -1076,6 +1075,7 @@
       selectedModels.push(model);
       updateSelectedModelsDisplay();
       updateCitation();
+      updateModelNameDisplay();
       
       const searchInput = document.querySelector('.model-search');
       if (searchInput) {
@@ -1106,6 +1106,13 @@
       selectedModels = selectedModels.filter(m => m.id !== modelId);
       updateSelectedModelsDisplay();
       updateCitation();
+      updateModelNameDisplay();
+    }
+
+    function updateModelNameDisplay() {
+      const modelDiv = document.getElementById('model-name');
+      if (!modelDiv) return;
+      modelDiv.textContent = selectedModels.map(m => m.name).join(' + ');
     }
 
     // Citation tab switching
@@ -1130,10 +1137,11 @@
 
     // Button actions
     async function downloadBadge() {
-      const badge = document.getElementById('badge');
-      const canvas = await html2canvas(badge, {
+      const badgeWrapper = document.getElementById('badge-wrapper');
+      const canvas = await html2canvas(badgeWrapper, {
         scale: 3,
-        backgroundColor: null
+        backgroundColor: null,
+        height: badgeWrapper.offsetHeight + 30
       });
       
       canvas.toBlob(blob => {
@@ -1164,6 +1172,7 @@
       initializeOptions();
       setupModelSearch();
       updateBadge();
+      updateModelNameDisplay();
       loadAIModels(); // Auto-load models
     });
   </script>


### PR DESCRIPTION
## Summary
- Show selected AI model names below the TRACE badge with subtle styling
- Include model names in natural and formal citations and badge PNG export
- Capture badge plus model attribution when downloading

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/trace/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68aff0cb78cc8332892487cb4da57d4a