### PR TITLE
Show both citation panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,31 +436,18 @@
     }
 
     /* Citation Section */
-    .citation-tabs {
-      display: flex;
-      border-bottom: 1px solid var(--gray);
-      margin-bottom: 0.5rem;
-    }
-
-    .citation-tab {
-      flex: 1;
-      padding: 0.5rem;
-      background: none;
-      border: none;
-      cursor: pointer;
-      font-size: 0.85rem;
-      color: #64748b;
-      transition: all 0.2s;
-    }
-
-    .citation-tab.active {
-      border-bottom: 2px solid var(--blue);
-      color: #1e293b;
+    /* Citation Section - Remove tab styles, add stacked layout */
+    .citation-header {
       font-weight: 600;
+      color: #1e293b;
+      font-size: 0.9rem;
+      padding-bottom: 0.5rem;
+      margin-bottom: 0.75rem;
+      border-bottom: 1px solid #e2e8f0;
     }
 
     .citation-panel {
-      display: none;
+      display: block; /* Changed from display: none */
       background: #f1f5f9;
       border-radius: 8px;
       padding: 1rem;
@@ -470,11 +457,11 @@
       color: #334155;
       min-height: 120px;
       white-space: pre-wrap;
+      margin-bottom: 1rem; /* Add spacing between panels */
     }
 
-    .citation-panel.active {
-      display: block;
-    }
+    /* Remove .citation-panel.active since all panels show */
+    /* Remove .citation-tab styles entirely */
 
     .button {
       display: inline-flex;
@@ -632,13 +619,17 @@
 
     <!-- Right Panel: Citation -->
     <div class="panel">
-      <div class="citation-tabs">
-        <button class="citation-tab active" data-tab="formal">Formal</button>
-        <button class="citation-tab" data-tab="natural">Natural Language</button>
+      <div class="citation-container">
+        <div class="citation-section">
+          <div class="citation-header">Formal Citation</div>
+          <div class="citation-panel" id="tab-formal"></div>
+        </div>
+
+        <div class="citation-section">
+          <div class="citation-header">Natural Language</div>
+          <div class="citation-panel" id="tab-natural"></div>
+        </div>
       </div>
-      
-      <div class="citation-panel active" id="tab-formal"></div>
-      <div class="citation-panel" id="tab-natural"></div>
     </div>
   </div>
 
@@ -1108,16 +1099,6 @@
       updateCitation();
     }
 
-    // Citation tab switching
-    document.querySelectorAll('.citation-tab').forEach(tab => {
-      tab.addEventListener('click', () => {
-        document.querySelectorAll('.citation-tab').forEach(t => t.classList.remove('active'));
-        document.querySelectorAll('.citation-panel').forEach(p => p.classList.remove('active'));
-        
-        tab.classList.add('active');
-        document.getElementById(`tab-${tab.dataset.tab}`).classList.add('active');
-      });
-    });
 
     // Style toggles
     document.getElementById('show-tags').addEventListener('change', (e) => {
@@ -1147,9 +1128,9 @@
     }
 
     function copyCitation() {
-      const activePanel = document.querySelector('.citation-panel.active');
-      navigator.clipboard.writeText(activePanel.textContent);
-      
+      const formalPanel = document.getElementById('tab-formal');
+      navigator.clipboard.writeText(formalPanel.textContent);
+
       // Visual feedback
       const btn = document.querySelector('.button.secondary');
       const originalText = btn.textContent;


### PR DESCRIPTION
## Summary
- Replace citation tabs with stacked panels and new header styling.
- Display formal and natural language citations together for easier comparison.
- Remove tab switching logic and copy the formal citation directly.

## Testing
- `npm test` *(fails: ENOENT open '/workspace/trace/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68aff11d0adc8332b7176229d006966e