### PR TITLE
feat: add badge background toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,6 +632,10 @@
             <input type="checkbox" id="grayscale-mode">
             Grayscale version
           </label>
+          <label>
+            <input type="checkbox" id="transparent-bg" checked>
+            Transparent background
+          </label>
         </div>
 
         <div class="actions">
@@ -1123,12 +1127,17 @@
       document.getElementById('badge').classList.toggle('grayscale', e.target.checked);
     });
 
+    document.getElementById('transparent-bg').addEventListener('change', (e) => {
+      document.getElementById('badge-wrapper').style.background = e.target.checked ? 'transparent' : '#ffffff';
+    });
+
     // Button actions
     async function downloadBadge() {
       const badgeWrapper = document.getElementById('badge-wrapper');
+      const isTransparent = document.getElementById('transparent-bg').checked;
       const canvas = await html2canvas(badgeWrapper, {
         scale: 3,
-        backgroundColor: null,
+        backgroundColor: isTransparent ? null : '#ffffff',
         height: badgeWrapper.offsetHeight + 30
       });
       


### PR DESCRIPTION
## Summary
- allow selecting transparent or white background for generated badge
- include toggle UI and update export logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aff200d15c8332be13d2bd49133d79