### PR TITLE
Rename peer review to general

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The level and type of human oversight applied after generation. This quadrant in
 
 - **Unreviewed**: No human checked the output before use
 - **Skimmed**: Quick review for tone and obvious issues only
-- **Peer Review**: Non-expert but knowledgeable person reviewed carefully
+- **General Review**: Non-expert but knowledgeable person reviewed carefully
 - **Expert Review**: Subject-matter expert verified accuracy and quality
 - **AI Self-Check**: The model was prompted to critique or improve its own output
 
@@ -86,7 +86,7 @@ Finding typos and homophone replacements (they're/their, its/it's) that verbal l
 
 ### Code Development
 Building interactive charts and mini-websites with coding assistant tools.
-- Typical badge: `Public-Creative-Augmented-Peer`
+- Typical badge: `Public-Creative-Augmented-General`
 
 ### Content Creation
 Generating drafts for blog posts, reports, or creative writing.
@@ -131,7 +131,7 @@ npx http-server
 **Citation**: "AI drafted content from public sources using a rewriting methodology. The output received a quick review for tone and obvious issues."
 
 ### Technical Documentation
-**Badge Code**: `M-Synthesis-Augmented-Peer`
+**Badge Code**: `M-Synthesis-Augmented-General`
 **Citation**: "AI synthesized information from its training data using augmented tools. A knowledgeable colleague reviewed the output carefully."
 
 ## Technical Details
@@ -201,18 +201,18 @@ Details: [natural language description]
 -------------------------
 ```
 AI Disclosure (2025-08-28)
-TRACE: S-P-G-P
+TRACE: S-P-G-G
 
 Role: Synthesis
 Data: Public
 Method: Guided
-Review: Peer
+Review: General
 
 AI Models Used:
 • Anthropic: Claude Opus 4.1 (anthropic/claude-opus-4.1)
 
-I used AI to synthesize information from multiple sources using public sources, through guided prompting. 
-The output underwent peer review. The AI model used was Anthropic: Claude Opus 4.1.
+I used AI to synthesize information from multiple sources using public sources, through guided prompting.
+The output underwent general review. The AI model used was Anthropic: Claude Opus 4.1.
 ```
 -------------------------
 

--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
       review: [
         {code: 'U', label: 'Unreviewed', desc: 'Not checked', exclusive: true},
         {code: 'S', label: 'Skimmed', desc: 'Quick read'},
-        {code: 'P', label: 'Peer', desc: 'Non-expert review'},
+        {code: 'G', label: 'General', desc: 'Non-expert review'},
         {code: 'E', label: 'Expert', desc: 'Expert reviewed'},
         {code: 'A', label: 'AI-Check', desc: 'Self-reviewed'}
       ]
@@ -718,16 +718,16 @@
         single: {
           'U': 'has not been reviewed',
           'S': 'was skimmed quickly',
-          'P': 'underwent peer review',
+          'G': 'underwent general review',
           'E': 'was expert reviewed',
           'A': 'was AI-checked for consistency'
         },
         combinations: {
-          'SP': 'was skimmed and peer reviewed',
+          'SG': 'was skimmed and underwent general review',
           'SE': 'was skimmed and expert reviewed',
-          'PE': 'underwent peer and expert review',
+          'GE': 'underwent general and expert review',
           'SA': 'was skimmed and AI-checked',
-          'SPE': 'was skimmed, peer reviewed, and expert reviewed'
+          'SGE': 'was skimmed, underwent general review, and expert reviewed'
         }
       }
     };


### PR DESCRIPTION
## Summary
- rename peer review option to general in the badge generator
- update natural language templates and example badges accordingly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aff28d96f8833296cfce7a0184a882