### PR TITLE
Add feedback email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Details: [natural language description]
 - Try local server for CORS issues
 - Models list falls back gracefully if API unavailable
 - Clear cache if badge generation fails
+- Send feedback: [clovenbradshaw@gmail.com](mailto:clovenbradshaw@gmail.com)
 
 ## Future Roadmap
 

--- a/index.html
+++ b/index.html
@@ -56,6 +56,16 @@
       color: #94a3b8;
     }
 
+    .feedback-link {
+      color: #3b82f6;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    .feedback-link:hover {
+      text-decoration: underline;
+    }
+
     .main-container {
       display: grid;
       grid-template-columns: 1fr auto 1fr;
@@ -587,6 +597,7 @@
       <p class="subtitle">Generate transparency badges for AI-assisted work</p>
       <p class="last-updated">Last Updated: August 28, 2025 - <a href="https://github.com/clovenbradshaw-ctrl/trace/blob/main/README.md">README</a></p>
     </div>
+    <a class="feedback-link" href="mailto:clovenbradshaw@gmail.com">Send Feedback</a>
   </header>
 
   <div class="main-container">


### PR DESCRIPTION
## Summary
- Add styled feedback mailto link in the header for easy contact.
- Document feedback address in Support & Troubleshooting section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b089b635c8833299bb47960ae5a89e